### PR TITLE
Add buffering

### DIFF
--- a/observer/observer.go
+++ b/observer/observer.go
@@ -194,17 +194,16 @@ func (o *Observer) handleEvent(event interface{}) {
 	// If this is the first event, set a timeout function.
 	if o.bufferTimer == nil {
 		o.bufferTimer = time.AfterFunc(o.bufferDuration, func() {
-			// Run all listeners for this event.
+			// Lock this function.
 			o.bufferMutex.Lock()
+			defer o.bufferMutex.Unlock()
 
-			// Send event buffer
+			// Send all events in event buffer
 			o.sendEvent(o.bufferEvents)
 
 			// Reset events buffer
 			o.bufferTimer = nil
 			o.bufferEvents = make([]interface{}, 0)
-
-			o.bufferMutex.Unlock()
 		})
 	}
 }

--- a/observer/observer_test.go
+++ b/observer/observer_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestOpen(t *testing.T) {
@@ -126,5 +127,34 @@ func TestWatch(t *testing.T) {
 
 	if output != tmpfn {
 		t.Error("error watching files.")
+	}
+}
+
+func TestSetBufferDuration(t *testing.T) {
+	var output []interface{}
+	var o Observer
+
+	o.Open()
+	defer o.Close()
+
+	done := make(chan bool)
+	defer close(done)
+
+	o.SetBufferDuration(1 * time.Second)
+
+	o.AddListener(func(e interface{}) {
+		output = e.([]interface{})
+		done <- true
+	})
+
+	o.Emit("done")
+	o.Emit("done")
+	o.Emit("done")
+	o.Emit("done")
+
+	<-done // blocks until listener is triggered
+
+	if len(output) != 4 {
+		t.Error("error SetBufferDuration.")
 	}
 }

--- a/observer/observer_test.go
+++ b/observer/observer_test.go
@@ -140,12 +140,21 @@ func TestSetBufferDuration(t *testing.T) {
 	done := make(chan bool)
 	defer close(done)
 
-	o.SetBufferDuration(1 * time.Second)
+	o.SetBufferDuration(50000 * time.Nanosecond)
 
 	o.AddListener(func(e interface{}) {
 		output = e.([]interface{})
 		done <- true
 	})
+
+	o.Emit("done")
+	o.Emit("done")
+
+	<-done // blocks until listener is triggered
+
+	if len(output) != 2 {
+		t.Error("error sending 2 buffered events.")
+	}
 
 	o.Emit("done")
 	o.Emit("done")
@@ -155,6 +164,6 @@ func TestSetBufferDuration(t *testing.T) {
 	<-done // blocks until listener is triggered
 
 	if len(output) != 4 {
-		t.Error("error SetBufferDuration.")
+		t.Error("error sending 4 buffered events.")
 	}
 }


### PR DESCRIPTION
**Description**

Add optional event buffering before sending them to listener functions.
In case of multiple events in short time, events get aggregated, and a list of all events is sent once to the listeners.

**Example**

``` go
o.Open()
o.SetBufferDuration(1 * time.Second)

o.AddListener(func(e interface{}) {
	output = e.([]interface{}) // => ["done", "done", "done", "done"]
})

o.Emit("done")
o.Emit("done")
o.Emit("done")
o.Emit("done")
```

